### PR TITLE
ZVISION: Add detection for Zork Nemesis and Zork Grand Inquisitor demos and Zork Grand Inquisitor DVD version

### DIFF
--- a/engines/zvision/detection.cpp
+++ b/engines/zvision/detection.cpp
@@ -87,10 +87,10 @@ static const ZVisionGameDescription gameDescriptions[] = {
 	},
 
 	{
-		// Zork Grand Inquisitor English version
+		// Zork Grand Inquisitor English CD version
 		{
 			"zgi",
-			0,
+			"CD",
 			AD_ENTRY1s("SCRIPTS.ZFS", "81efd40ecc3d22531e211368b779f17f", 8336944),
 			Common::EN_ANY,
 			Common::kPlatformWindows,
@@ -109,6 +109,20 @@ static const ZVisionGameDescription gameDescriptions[] = {
 			Common::EN_ANY,
 			Common::kPlatformWindows,
 			ADGF_DEMO,
+			GUIO1(GUIO_NONE)
+		},
+		GID_GRANDINQUISITOR
+	},
+
+	{
+		// Zork Grand Inquisitor English DVD version
+		{
+			"zgi",
+			"DVD",
+			AD_ENTRY1s("SCRIPTS.ZFS", "03157a3399513bfaaf8dc6d5ab798b36", 8433326),
+			Common::EN_ANY,
+			Common::kPlatformWindows,
+			ADGF_NO_FLAGS,
 			GUIO1(GUIO_NONE)
 		},
 		GID_GRANDINQUISITOR


### PR DESCRIPTION
I added detection for the demos of Zork Nemesis and Zork Grand Inquisitor, and the DVD version of Zork Grand Inquisitor.

All three start up ok. The ZGI demo has a spot where it exits (but not seg fault) due to an audio issue (when going down into the well). The ZN demo works, but I get some missing script warnings and eventually end up in a location where there's no way to get to another location, and ScummVM hangs on exit. The ZGI DVD version seems to work as well as the CD version, though the DVD-specific options in the preferences seem to do nothing so far (MPEG, lineskip).

Downloads of the demos preconfigured, if you want to test:
ZGI Demo: https://www.dropbox.com/s/k20dpptna4a4gbd/ZGI-DEMO.zip?dl=0
ZN Demo: https://www.dropbox.com/s/peekzhmsdv9dhnf/ZN-DEMO.zip?dl=0
